### PR TITLE
Add InvCrashFix softdepend

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -9,6 +9,8 @@ authors:
 depend:
 - EconomyAPI
 - SellAll
+softdepend:
+- InvCrashFix
 
 permissions:
   betterminion.command:


### PR DESCRIPTION
Adding this will make PocketMine-MP load the InvCrashFix plugin first if the plugin is installed, however it is not required to have the InvCrashFix plugin installed.